### PR TITLE
Fixes missing Python requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM python:3.8-slim
 
 RUN apt-get update && \
     apt-get install -y curl python && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y curl python && \
     rm -rf /var/lib/apt/lists/*
 
+RUN python -m pip install six
 RUN curl -s https://shopify.github.io/themekit/scripts/install.py | python
 
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
Related to [this issue](https://github.com/Shopify/themekit/issues/856).

- Switched out Debian Stable Slim for Python Slim, as it includes PIP out of the box.
- Installed the missing package (six)